### PR TITLE
Allow to specify XLint level for AspectJ compiler in gradle DSL

### DIFF
--- a/src/main/groovy/com/meituan/android/aspectj/AspectJExtension.groovy
+++ b/src/main/groovy/com/meituan/android/aspectj/AspectJExtension.groovy
@@ -23,6 +23,8 @@ class AspectJExtension {
 
     private boolean disableWhenDebug = false
 
+    private XLintLevel xlintLevel = XLintLevel.ERROR
+
     public void exclude(Map<String, String> excludeProperties) {
         excludeRuleContainer.add(excludeProperties)
     }
@@ -73,5 +75,19 @@ class AspectJExtension {
 
     void setDisableWhenDebug(boolean disableWhenDebug) {
         this.disableWhenDebug = disableWhenDebug
+    }
+
+    public void xlintLevel(XLintLevel xlintLevel) {
+        this.xlintLevel = xlintLevel
+    }
+
+    XLintLevel getXlintLevel() {
+        return xlintLevel
+    }
+
+    public enum XLintLevel {
+        IGNORE,
+        WARNING,
+        ERROR
     }
 }

--- a/src/main/groovy/com/meituan/android/aspectj/AspectJTransform.groovy
+++ b/src/main/groovy/com/meituan/android/aspectj/AspectJTransform.groovy
@@ -159,6 +159,8 @@ public class AspectJTransform extends Transform {
         final String bootpath = Joiner.on(File.pathSeparator).join(project.android.bootClasspath)
         output = outputProvider.getContentLocation("main", outputTypes, Sets.immutableEnumSet(QualifiedContent.Scope.PROJECT), Format.DIRECTORY);
 
+        final String xlintLevel = project.aspectj.xlintLevel.toString().toLowerCase()
+
         // assemble compile options
         logger.quiet "Weaving ..."
         def args = [
@@ -168,6 +170,7 @@ public class AspectJTransform extends Transform {
                 "-encoding", project.aspectj.compileOptions.encoding,
                 "-inpath", inpath,
                 "-d", output.absolutePath,
+                "-Xlint:" + xlintLevel,
                 "-bootclasspath", bootpath]
 
         // append classpath argument if any


### PR DESCRIPTION
Some classes might not be available while weaving, like classes from Apache Http on Android. This allows to ignore such errors.
