### PR TITLE
Fix dex exception from simulation: local variable type mismatch

### DIFF
--- a/src/main/groovy/com/meituan/android/aspectj/AspectJTransform.groovy
+++ b/src/main/groovy/com/meituan/android/aspectj/AspectJTransform.groovy
@@ -168,6 +168,7 @@ public class AspectJTransform extends Transform {
                 "-encoding", project.aspectj.compileOptions.encoding,
                 "-inpath", inpath,
                 "-d", output.absolutePath,
+                "-Xset:generateNewLocalVariableTables=false", // for fixing problems with dex, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=470658
                 "-bootclasspath", bootpath]
 
         // append classpath argument if any


### PR DESCRIPTION
Fixes EXCEPTION FROM SIMULATION:
local variable type mismatch: attempt to set or access a value of type java.lang.Object using a local variable of type int. This is symptomatic of .class transformation tools that ignore local variable information.

More here:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=470658
